### PR TITLE
Force the Editor to use timestamps instead of date strings when creating the IDs

### DIFF
--- a/vendor/assets/javascripts/medium-editor.js
+++ b/vendor/assets/javascripts/medium-editor.js
@@ -780,7 +780,7 @@ MediumEditor.extensions = {};
                 timeout = null,
                 previous = 0,
                 later = function () {
-                    previous = Date.now();
+                    previous = new Date().getTime();
                     timeout = null;
                     result = func.apply(context, args);
                     if (!timeout) {
@@ -793,7 +793,7 @@ MediumEditor.extensions = {};
             }
 
             return function () {
-                var now = Date.now(),
+                var now = new Date().getTime(),
                     remaining = wait - (now - previous);
 
                 context = this;
@@ -6839,7 +6839,7 @@ MediumEditor.extensions = {};
 
     function createContentEditable(textarea) {
         var div = this.options.ownerDocument.createElement('div'),
-            now = Date.now(),
+            now = new Date().getTime(),
             uniqueId = 'medium-editor-' + now,
             atts = textarea.attributes;
 


### PR DESCRIPTION
I noticed that sometimes the editor was taking the ID with a datestring:
`Wed Sep 21 2016 09:26:24 GMT+0200 (CEST)`

And sometimes with a timestamp:
`1474442813815`

This could happen because some other library overwrites Date.now().

To avoid this inconsistent behavior, I've changed the way the date is retrieved, to make sure it's always ALWAYS a timestamp.