### PR TITLE
Change first argument in MediumEditor function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You need to initialize Medium Editor with any selector of div, example:
 <div class="editable"></div>
 
 <script>
-  var editor = new MediumEditor('.editor', {
+  var editor = new MediumEditor('.editable', {
     // options go here
   });
 </script>


### PR DESCRIPTION
I updated the first argument so that it matches the class name of the div above, instead of the name of the js var (as previously). This prevented the script from targeting the right container.